### PR TITLE
add notifications when mad science folks star repos

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ async function init () {
   await fs.mkdir(DB_PATH, { recursive: true })
 
   try {
-    state = JSON.parse(await fs.readFile(STATE_PATH, 'utf8'))
+    const savedState = JSON.parse(await fs.readFile(STATE_PATH, 'utf8'))
+    state = { ...state, ...savedState }
   } catch (err) {
     // First run of the program
   }


### PR DESCRIPTION
- scan once per hour.
- show up to 3 starred repos per user.
- ignores repo if the user is already on the mad science list.
  - Hopefully this keeps the spam down a bit for new mad scientist repos that are starred by others.

@feross what do you think?


![image](https://user-images.githubusercontent.com/360233/122847062-c24e3a00-d2cc-11eb-9088-0901acc6899b.png)

